### PR TITLE
Add trim_output option to archive.extracted.

### DIFF
--- a/sun-java/init.sls
+++ b/sun-java/init.sls
@@ -56,6 +56,7 @@ unpack-jdk-archive:
     - archive_format: {{ java.archive_type }}
     - user: root
     - group: root
+    - trim_output: true
     - if_missing: {{ java.java_realcmd }}
     - onchanges:
       - cmd: download-jdk-archive


### PR DESCRIPTION
Otherwise the output is big and ci job fails with: Job's log exceeded limit of 4194304 bytes.

@marek-knappe FYI